### PR TITLE
rm points passthrough when width==0

### DIFF
--- a/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/compare_map_filter/distance_based_compare_map_filter_nodelet.cpp
+++ b/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/compare_map_filter/distance_based_compare_map_filter_nodelet.cpp
@@ -71,8 +71,6 @@ void DistanceBasedCompareMapFilterNodelet::filter(
   }
 
   pcl::toROSMsg(*pcl_output, output);
-  if (output.width == 0)
-    pcl::toROSMsg(*pcl_input, output);
   output.header = input->header;
 }
 


### PR DESCRIPTION
マップマッチした点群の数をゼロのときも取得できるようにするための変更
→既存の動作のためには、RVVL側でloam_points_selectorノードが必要になる。