### PR TITLE
Revert "Feature/modify covariance"

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/util_func.h
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/util_func.h
@@ -244,12 +244,12 @@ static geometry_msgs::PoseArray createRandomPoseArray(
 {
   std::random_device seed_gen;
   std::default_random_engine engine(seed_gen());
-  std::normal_distribution<> x_distribution(0.0, std::sqrt(base_pose_with_cov.pose.covariance[0]));
-  std::normal_distribution<> y_distribution(0.0, std::sqrt(base_pose_with_cov.pose.covariance[1 * 6 + 1]));
-  std::normal_distribution<> z_distribution(0.0, std::sqrt(base_pose_with_cov.pose.covariance[2 * 6 + 2]));
-  std::normal_distribution<> roll_distribution(0.0, std::sqrt(base_pose_with_cov.pose.covariance[3 * 6 + 3]));
-  std::normal_distribution<> pitch_distribution(0.0, std::sqrt(base_pose_with_cov.pose.covariance[4 * 6 + 4]));
-  std::normal_distribution<> yaw_distribution(0.0, std::sqrt(base_pose_with_cov.pose.covariance[5 * 6 + 5]));
+  std::normal_distribution<> x_distribution(0.0, base_pose_with_cov.pose.covariance[0]);
+  std::normal_distribution<> y_distribution(0.0, base_pose_with_cov.pose.covariance[1 * 6 + 1]);
+  std::normal_distribution<> z_distribution(0.0, base_pose_with_cov.pose.covariance[2 * 6 + 2]);
+  std::normal_distribution<> roll_distribution(0.0, base_pose_with_cov.pose.covariance[3 * 6 + 3]);
+  std::normal_distribution<> pitch_distribution(0.0, base_pose_with_cov.pose.covariance[4 * 6 + 4]);
+  std::normal_distribution<> yaw_distribution(0.0, base_pose_with_cov.pose.covariance[5 * 6 + 5]);
 
   const auto base_rpy = getRPY(base_pose_with_cov);
 

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -556,7 +556,7 @@ geometry_msgs::PoseWithCovarianceStamped NDTScanMatcher::alignUsingMonteCarlo(
   }
 
   // generateParticle
-  const auto initial_pose_array = createRandomPoseArray(initial_pose_with_cov, 1000);
+  const auto initial_pose_array = createRandomPoseArray(initial_pose_with_cov, 100);
 
   return alignUsingMonteCarlo(ndt_ptr, initial_pose_array);
 }

--- a/localization/util/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/util/pose_initializer/src/pose_initializer_core.cpp
@@ -137,7 +137,12 @@ void PoseInitializer::callbackGNSSPoseCov(
   getHeight(*pose_cov_msg_ptr, add_height_pose_msg_ptr);
 
   // TODO
-  add_height_pose_msg_ptr->pose.covariance = pose_cov_msg_ptr->pose.covariance;
+  add_height_pose_msg_ptr->pose.covariance[0] = 1.0;
+  add_height_pose_msg_ptr->pose.covariance[1 * 6 + 1] = 1.0;
+  add_height_pose_msg_ptr->pose.covariance[2 * 6 + 2] = 0.01;
+  add_height_pose_msg_ptr->pose.covariance[3 * 6 + 3] = 0.01;
+  add_height_pose_msg_ptr->pose.covariance[4 * 6 + 4] = 0.01;
+  add_height_pose_msg_ptr->pose.covariance[5 * 6 + 5] = 3.14;
 
   geometry_msgs::PoseWithCovarianceStamped::Ptr aligned_pose_msg_ptr(
     new geometry_msgs::PoseWithCovarianceStamped);


### PR DESCRIPTION
Reverts Synesthesias/AutowareArchitectureProposal.iv#3

- 概要
  - gnssを用いた初期位置設定はpose_initializerはもちいなくなった(代わりにpose_resetterを用いる)ため、この変更を戻します。

- 備考
  - 他とタイミングをあわせる必要のないものなのでいつ実施してもいいと思います。