### PR TITLE
Porting autoware_localization_srvs

### DIFF
--- a/localization/util/autoware_localization_srvs/CMakeLists.txt
+++ b/localization/util/autoware_localization_srvs/CMakeLists.txt
@@ -1,27 +1,15 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.14)
 project(autoware_localization_srvs)
 
-find_package(catkin REQUIRED COMPONENTS
-  message_generation
-  std_msgs
-  geometry_msgs
+find_package(ament_cmake_auto REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+ament_auto_find_build_dependencies()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/PoseArray.srv"
+  "srv/PoseWithCovarianceStamped.srv"
+  DEPENDENCIES geometry_msgs
 )
 
-add_service_files(
-  FILES
-  PoseWithCovarianceStamped.srv
-  PoseArray.srv
-)
-
-generate_messages(
-  DEPENDENCIES
-  std_msgs
-  geometry_msgs
-)
-
-catkin_package(
-  CATKIN_DEPENDS
-  message_runtime
-  std_msgs
-  geometry_msgs
-)
+ament_auto_package()

--- a/localization/util/autoware_localization_srvs/package.xml
+++ b/localization/util/autoware_localization_srvs/package.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>autoware_localization_srvs</name>
-  <version>0.1.0</version>
-  <description>The autoware_localization_srvs package</description>
-  <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
-  <license>Apache 2</license>
+  <version>0.0.1</version>
+  <description>ROS2 port of autoware_localization_srvs</description>
+  <maintainer email="user@example.com">ROS2 Maintainer</maintainer>
+  <license>Apache-2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>geometry_msgs</build_depend>
 
-  <build_depend>message_generation</build_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
 
-  <depend>std_msgs</depend>
-  <depend>geometry_msgs</depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
+
 </package>


### PR DESCRIPTION
ament_cmake_auto() で問題が起きていることに注意

<member_of_group>rosidl_interface_packages</member_of_group> を本来は<export>タグ内に書くべきだが、exportの外に書かないとビルドが通らない

こういった問題があるので、ament_cmake_auto()を避けた方がいいかもしれない